### PR TITLE
Allow importing datasources with preconfigured uids via API

### DIFF
--- a/roles/grafana/tasks/datasources.yml
+++ b/roles/grafana/tasks/datasources.yml
@@ -20,6 +20,7 @@
     aws_secret_key: "{{ item.aws_secret_key | default(omit) }}"
     aws_credentials_profile: "{{ item.aws_credentials_profile | default(omit) }}"
     aws_custom_metrics_namespaces: "{{ item.aws_custom_metrics_namespaces | default(omit) }}"
+    uid: "{{ item.uid | default(omit) }}"
   loop: "{{ grafana_datasources }}"
   when: "not grafana_use_provisioning"
 


### PR DESCRIPTION
Allow specifying datasource uids like this,

```yaml
grafana_datasources:
  - name: Galaxy
    type: influxdb
    access: proxy
    url: "{{ influxdb.url }}"
    isDefault: true
    version: 1
    editable: false
    database: galaxy
    user: "{{ influxdb.grafana.username }}"
    password: "{{ influxdb.grafana.password }}"
    uid: P9B81C0353945995B
  [...]
  - name: GRT Tool Usage
    type: influxdb
    access: proxy
    url: "{{ influxdb.url }}"
    version: 1
    editable: false
    database: grt
    user: "{{ influxdb.grafana.username }}"
    password: "{{ influxdb.grafana.password }}"
    uid: PA4245ACF5D5D4D2B
```

so that imported dashboards work (as they reference specific datasources via their uids).